### PR TITLE
Add more playback controls for script players

### DIFF
--- a/contrib/examples/playkiiroo.go
+++ b/contrib/examples/playkiiroo.go
@@ -22,12 +22,12 @@ var (
 	noact    = flag.Bool("noact", false, "simulate")
 )
 
-type Launch interface {
+type launch interface {
 	Move(position, speed int)
 }
-type FakeLaunch string
+type fakeLaunch string
 
-func (f FakeLaunch) Move(position, speed int) {
+func (f fakeLaunch) Move(position, speed int) {
 	log.Printf("%s: Position=%d, Speed=%d", f, position, speed)
 }
 
@@ -35,9 +35,9 @@ func main() {
 	flag.Parse()
 
 	// Create Launch by connecting to or faking one
-	var l Launch
+	var l launch
 	if *noact {
-		l = FakeLaunch("FakeLaunch")
+		l = fakeLaunch("FakeLaunch")
 	} else {
 		ctx, cancel := context.WithTimeout(
 			context.Background(),
@@ -52,7 +52,7 @@ func main() {
 			log.Fatal(err)
 		}
 
-		l = Launch(la)
+		l = launch(la)
 	}
 
 	// Create a Kiiroo script player

--- a/protocol/kiiroo/algorithm_default.go
+++ b/protocol/kiiroo/algorithm_default.go
@@ -1,23 +1,27 @@
 package kiiroo
 
-import "time"
+import (
+	"time"
+
+	"github.com/funjack/launchcontrol/protocol"
+)
 
 // DefaultAlgorithm implements the Algorithm interface trying to mimik the
 // Kiiroo apps.
 type DefaultAlgorithm struct{}
 
 // Actions converts Kiiroo events into Actions that can be send to a Launch.
-func (da DefaultAlgorithm) Actions(es Events) []TimedAction {
+func (da DefaultAlgorithm) Actions(es Events) []protocol.TimedAction {
 	var (
 		prevEvent           Event
-		prevAction          TimedAction
+		prevAction          protocol.TimedAction
 		actionCount         int
 		position            togglePosition
 		speed, limitedSpeed int
 	)
 
 	// count(actions) <= count(events)
-	actions := make([]TimedAction, len(es))
+	actions := make([]protocol.TimedAction, len(es))
 
 	for _, e := range es {
 		// Move only when value is different from previous event

--- a/protocol/kiiroo/player_test.go
+++ b/protocol/kiiroo/player_test.go
@@ -2,36 +2,58 @@ package kiiroo
 
 import (
 	"bytes"
+	"fmt"
 	"testing"
 	"time"
+
+	"github.com/funjack/launchcontrol/protocol"
 )
 
+// Badish input scenario, contains dups and short timings
+var scenario = "{1.00:1,1.50:4,1.51:4,1.51:3,1.52:4,1.66:1,1.84:2,1.85:3,1.90:4,1.95:1,2.00:2,2.20:4,2.45:2}"
+
+func playerwithscenario(scenario string) (protocol.SkippableScriptPlayer, error) {
+	b := bytes.NewBufferString(scenario)
+	sp := NewScriptPlayer()
+	err := sp.Load(b)
+	return sp, err
+}
+
+type actionValidator struct {
+	LastPostion int
+	LastTime    time.Duration
+}
+
+// Validate takes a position and time and tests if that is allowed compared to
+// previous values validated.
+func (a *actionValidator) Validate(p int, t time.Duration) error {
+	defer func() {
+		a.LastPostion = p
+		a.LastTime = t
+	}()
+
+	if p == a.LastPostion {
+		return fmt.Errorf("received the same position in a row")
+	}
+	if a.LastTime > 0 && (t-a.LastTime) < (time.Millisecond*150) {
+		return fmt.Errorf("time between events not big enough: %s", t-a.LastTime)
+	}
+	return nil
+}
+
 func TestPlay(t *testing.T) {
-	b := bytes.NewBufferString("{1.00:1,1.50:4,1.51:3,1.52:4,1.66:1,1.84:2,1.85:3,1.90:4,1.95:1,2.00:2,2.20:4,2.45:2}")
-	k := NewScriptPlayer()
-	err := k.Load(b)
+	k, err := playerwithscenario(scenario)
 	if err != nil {
 		t.Error(err)
 	}
 
-	var (
-		lastPosition  int
-		lastEventTime time.Duration
-	)
-
+	av := actionValidator{}
 	starttime := time.Now()
 	for a := range k.Play() {
 		eventtime := time.Now().Sub(starttime)
 		t.Logf("Action: %s: %d,%d", eventtime, a.Position, a.Speed)
-		if a.Position == lastPosition {
-			t.Error("received the same position in a row")
+		if err := av.Validate(a.Position, eventtime); err != nil {
+			t.Error(err)
 		}
-
-		if lastEventTime > 0 && (eventtime-lastEventTime) < (time.Millisecond*150) {
-			t.Errorf("time between events not big enough: %s", eventtime-lastEventTime)
-		}
-
-		lastPosition = a.Position
-		lastEventTime = eventtime
 	}
 }

--- a/protocol/kiiroo/types.go
+++ b/protocol/kiiroo/types.go
@@ -17,13 +17,7 @@ var (
 
 // Algorithm interface converts Kiiroo events into TimedActions.
 type Algorithm interface {
-	Actions(es Events) []TimedAction
-}
-
-// TimedAction wraps Action together with a timestamp.
-type TimedAction struct {
-	protocol.Action
-	Time time.Duration
+	Actions(es Events) []protocol.TimedAction
 }
 
 // Event contains the values of a single Kiiroo event.

--- a/protocol/player.go
+++ b/protocol/player.go
@@ -1,0 +1,147 @@
+package protocol
+
+import (
+	"errors"
+	"time"
+)
+
+var (
+	// ErrPlaying is the error returned when an action is requested that is
+	// not allowed while playing.
+	ErrPlaying = errors.New("action not allowed while playing")
+	// ErrStopped is the error returned when an action is requested that is
+	// not allowed while stopped.
+	ErrStopped = errors.New("action not allowed while stopped")
+)
+
+// TimedActionsPlayer can playback an array of TimeActions. It can be used by
+// protocols that can pre-caluculate TimeActions.
+//
+// All of the SkippableScriptPlayer methods are implemented except for
+// ScriptLoader. Protocols only need to implement ScriptLoader themselves and
+// set the Script field with their result.
+type TimedActionsPlayer struct {
+	Script []TimedAction
+
+	isPlaying      bool
+	cancelPlaying  chan bool
+	stoppedPlaying chan bool
+
+	startPosition time.Duration
+	pausePosition time.Duration
+
+	startTime  time.Time
+	actionChan chan Action
+}
+
+// NewTimedActionsPlayer returns a new TimedActionsPlayer.
+func NewTimedActionsPlayer() *TimedActionsPlayer {
+	return &TimedActionsPlayer{
+		cancelPlaying:  make(chan bool),
+		stoppedPlaying: make(chan bool),
+	}
+}
+
+// Play will start executing the loaded script from the start.
+func (k *TimedActionsPlayer) Play() <-chan Action {
+	return k.PlayFrom(0)
+}
+
+// PlayFrom will start executing the loaded script from the given position.
+func (k *TimedActionsPlayer) PlayFrom(p time.Duration) <-chan Action {
+	if k.isPlaying == true {
+		return k.actionChan
+	}
+
+	k.actionChan = make(chan Action)
+	k.startTime = time.Now()
+	k.startPosition = p
+	go k.startPlaying()
+	return k.actionChan
+}
+
+// Position will return the current position in the script.
+func (k *TimedActionsPlayer) Position() time.Duration {
+	if !k.isPlaying {
+		return k.pausePosition
+	}
+	// Now()+startPosition - startTime
+	return time.Now().Add(k.startPosition).Sub(k.startTime)
+}
+
+// Stop stops playback and resets player.
+func (k *TimedActionsPlayer) Stop() error {
+	if !k.isPlaying {
+		return ErrStopped
+	}
+	k.cancelPlaying <- true
+	<-k.stoppedPlaying
+	k.reset()
+	return nil
+}
+
+// Pause will stop playback at the current position.
+func (k *TimedActionsPlayer) Pause() error {
+	if !k.isPlaying {
+		return ErrStopped
+	}
+	k.pausePosition = k.Position()
+	k.cancelPlaying <- true
+	<-k.stoppedPlaying
+	return nil
+}
+
+// Resume will continue playback from the paused location.
+func (k *TimedActionsPlayer) Resume() error {
+	if k.isPlaying {
+		return ErrPlaying
+	}
+	k.startPosition = k.pausePosition
+	k.startTime = time.Now()
+	go k.startPlaying()
+	return nil
+}
+
+// Skip will jump to a specific position.
+func (k *TimedActionsPlayer) Skip(p time.Duration) error {
+	if !k.isPlaying {
+		return ErrStopped
+	}
+	k.Pause()
+	k.pausePosition = p
+	k.Resume()
+	return nil
+}
+
+// startPlaying is the actual play loop sending out actions called as a
+// goroutine.
+func (k *TimedActionsPlayer) startPlaying() {
+	k.isPlaying = true
+	for _, a := range k.Script {
+		if a.Time < k.startPosition {
+			continue
+		}
+		select {
+		case <-k.cancelPlaying:
+			k.isPlaying = false
+			k.stoppedPlaying <- true
+			return
+		case <-time.After(a.Time - k.Position()):
+			k.actionChan <- Action{
+				Position: a.Position,
+				Speed:    a.Speed,
+			}
+		}
+	}
+	// end of script reached
+	k.reset()
+	k.isPlaying = false
+}
+
+// reset rewinds the player when playback has finished or is stopped.
+func (k *TimedActionsPlayer) reset() {
+	close(k.actionChan)
+	k.pausePosition = 0 // Be kind rewind
+	k.isPlaying = false
+	k.startTime = time.Time{}
+}

--- a/protocol/player_test.go
+++ b/protocol/player_test.go
@@ -1,0 +1,162 @@
+package protocol
+
+import (
+	"testing"
+	"time"
+)
+
+var script = []TimedAction{
+	{
+		Action{
+			Position: 5,
+			Speed:    50,
+		},
+		time.Millisecond * 50,
+	},
+	{
+		Action{
+			Position: 50,
+			Speed:    40,
+		},
+		time.Millisecond * 100,
+	},
+	{
+		Action{
+			Position: 90,
+			Speed:    90,
+		},
+		time.Millisecond * 150,
+	},
+	{
+		Action{
+			Position: 30,
+			Speed:    30,
+		},
+		time.Millisecond * 200,
+	},
+}
+
+func TestPlay(t *testing.T) {
+	p := NewTimedActionsPlayer()
+	p.Script = script
+
+	var eventCount int
+	starttime := time.Now()
+	for a := range p.Play() {
+		eventtime := time.Now().Sub(starttime)
+		t.Logf("Action: %s: %d,%d", eventtime, a.Position, a.Speed)
+		eventCount++
+	}
+	playTime := time.Now().Sub(starttime)
+
+	if eventCount != len(script) {
+		t.Errorf("not all actions were played, want %d, got %d",
+			len(script), eventCount)
+	}
+	want := script[len(script)-1].Time
+	if playTime.Nanoseconds()/1e6 != want.Nanoseconds()/1e6 {
+		t.Errorf("script was not played back at correct speed")
+	}
+}
+
+func TestPauseResume(t *testing.T) {
+	p := NewTimedActionsPlayer()
+	p.Script = script
+
+	pauseTime := time.Millisecond * 100
+
+	go func() {
+		<-time.After(time.Millisecond * 100)
+		if err := p.Pause(); err != nil {
+			t.Error(err)
+		}
+		<-time.After(pauseTime)
+		if err := p.Resume(); err != nil {
+			t.Error(err)
+		}
+	}()
+
+	var eventCount int
+	starttime := time.Now()
+	for _ = range p.Play() {
+		eventCount++
+	}
+	playTime := time.Now().Sub(starttime)
+
+	if eventCount != len(script) {
+		t.Errorf("not all actions were played, want %d, got %d",
+			len(script), eventCount)
+	}
+	want := script[len(script)-1].Time + pauseTime
+	if playTime.Nanoseconds()/1e6 != want.Nanoseconds()/1e6 {
+		t.Errorf("script was not played back at correct speed")
+	}
+}
+
+func TestStop(t *testing.T) {
+	p := NewTimedActionsPlayer()
+	p.Script = script
+
+	stopTime := time.Millisecond * 75
+
+	go func() {
+		<-time.After(stopTime)
+		if err := p.Stop(); err != nil {
+			t.Error(err)
+		}
+	}()
+
+	starttime := time.Now()
+	for _ = range p.Play() {
+		// pass
+	}
+	playTime := time.Now().Sub(starttime)
+
+	if playTime.Nanoseconds()/1e6 != stopTime.Nanoseconds()/1e6 {
+		t.Errorf("script was not stopped at the right time, want: %s, got: %s",
+			stopTime, playTime)
+	}
+}
+
+func TestSkip(t *testing.T) {
+	cases := []struct {
+		Name string
+		At   time.Duration
+		To   time.Duration
+	}{
+		{
+			Name: "Forward",
+			At:   time.Millisecond * 50,
+			To:   time.Millisecond * 150,
+		},
+		{
+			Name: "Back",
+			At:   time.Millisecond * 50,
+			To:   time.Millisecond * 150,
+		},
+	}
+
+	for _, c := range cases {
+		p := NewTimedActionsPlayer()
+		p.Script = script
+
+		go func() {
+			<-time.After(c.At)
+			if err := p.Skip(c.To); err != nil {
+				t.Error(err)
+			}
+		}()
+
+		starttime := time.Now()
+		for _ = range p.Play() {
+			// pass
+		}
+		playTime := time.Now().Sub(starttime)
+		want := script[len(script)-1].Time - (c.To - c.At)
+
+		if playTime.Nanoseconds()/1e6 != want.Nanoseconds()/1e6 {
+			t.Errorf("%s: player did not skip correctly, want: %s, got: %s",
+				c.Name, want, playTime)
+		}
+	}
+}

--- a/protocol/types.go
+++ b/protocol/types.go
@@ -12,15 +12,30 @@ type Action struct {
 	Speed    int
 }
 
+// TimedAction wraps Action together with a timestamp.
+type TimedAction struct {
+	Action
+	Time time.Duration
+}
+
+// ScriptLoader is the interface that wraps the Load method.
+type ScriptLoader interface {
+	// Load a script from the provided reader.
+	Load(io.Reader) error
+}
+
 // ScriptPlayer is an interface that has the basic functions to load and play a
 // script. It is supposed to be used to abstract different protocols for the
 // player.
 type ScriptPlayer interface {
-	// Load a script from the provided reader.
-	Load(io.Reader) error
+	ScriptLoader
+
 	// Start playback of the loaded script the reader channel should be
 	// attached to a device.
 	Play() <-chan Action
+
+	// Stop stops playback and resets the player.
+	Stop() error
 }
 
 // PausableScriptPlayer is a ScriptPlayer that can be paused and resumed.
@@ -28,9 +43,9 @@ type PausableScriptPlayer interface {
 	ScriptPlayer
 
 	// Pause playback.
-	Pause()
+	Pause() error
 	// Resume playback from the current position.
-	Resume()
+	Resume() error
 }
 
 // SkippableScriptPlayer is a PausableScriptPlayer that can jump to a time
@@ -39,7 +54,7 @@ type SkippableScriptPlayer interface {
 	PausableScriptPlayer
 
 	// Skip (jump) to the specified position/timecode.
-	Skip(position time.Duration)
+	Skip(position time.Duration) error
 }
 
 // Mover interface provides a device that can move to a position in percent


### PR DESCRIPTION
Add more control over playback of scripts by providing a timed actions
script player that can: start, stop, pause, resume and skip to a
certain time code.

Time actions are just an orderd series of timecodes with a Launch
position,speed percent that can be send to the Launch. Protocols that
can pre-calculate these timed actions only have to implement the
ScriptLoader interface themselves.

The Kiiroo player has been migrated to use the TimedActionsPlayer.