### PR TITLE
Expose loaded script and playing actions

### DIFF
--- a/action/controller.go
+++ b/action/controller.go
@@ -1,6 +1,7 @@
 package action
 
 import (
+	"encoding/json"
 	"log"
 	"mime"
 	"net/http"
@@ -75,6 +76,24 @@ func (c *Controller) SkipHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	handleManagerError(w, c.manager.Skip(p))
+}
+
+// DumpHandler is a http.Handler to dump the current script.
+func (c *Controller) DumpHandler(w http.ResponseWriter, r *http.Request) {
+	script, err := c.manager.Dump()
+	if err != nil {
+		handleManagerError(w, err)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	e := json.NewEncoder(w)
+	err = e.Encode(&script)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte("internal server error"))
+	}
+	return
 }
 
 // handleManagerError writes a http response based on a manager error.

--- a/control/controller.go
+++ b/control/controller.go
@@ -1,4 +1,4 @@
-package action
+package control
 
 import (
 	"encoding/json"

--- a/control/controller.go
+++ b/control/controller.go
@@ -9,17 +9,17 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/funjack/launchcontrol/manager"
+	"github.com/funjack/launchcontrol/device"
 	"github.com/gorilla/websocket"
 )
 
 // Controller translates http requests into manager actions.
 type Controller struct {
-	manager *manager.LaunchManager
+	manager *device.LaunchManager
 }
 
 // NewController returns a new controller for the given manager.
-func NewController(m *manager.LaunchManager) *Controller {
+func NewController(m *device.LaunchManager) *Controller {
 	return &Controller{
 		manager: m,
 	}
@@ -133,10 +133,10 @@ func handleManagerError(w http.ResponseWriter, err error) {
 	case nil:
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte("OK\n"))
-	case manager.ErrNotSupported:
+	case device.ErrNotSupported:
 		w.WriteHeader(http.StatusConflict)
 		w.Write([]byte("operation not supported by loaded script type\n"))
-	case manager.ErrNotPlaying:
+	case device.ErrNotPlaying:
 		w.WriteHeader(http.StatusConflict)
 		w.Write([]byte("operation cannot be executed when not playing\n"))
 	default:

--- a/control/doc.go
+++ b/control/doc.go
@@ -1,0 +1,6 @@
+/*
+Package control handles incoming requests and actions.
+
+The Controller type wraps a LaunchManager and implements HTTP handlers for it.
+*/
+package control

--- a/control/loader.go
+++ b/control/loader.go
@@ -1,4 +1,4 @@
-package action
+package control
 
 import (
 	"bytes"

--- a/device/device.go
+++ b/device/device.go
@@ -1,4 +1,4 @@
-package manager
+package device
 
 import (
 	"context"

--- a/device/device_test.go
+++ b/device/device_test.go
@@ -157,6 +157,9 @@ STOP:
 func TestStop(t *testing.T) {
 	fake := &fakeLaunch{}
 	lm := NewLaunchManager(fake)
+	if err := lm.Stop(); err != nil {
+		t.Errorf("stop on empty player did return an error")
+	}
 	p := protocol.NewTimedActionsPlayer()
 	p.Script = testScript
 	lm.SetScriptPlayer(p)
@@ -170,6 +173,8 @@ func TestStop(t *testing.T) {
 	if err := lm.Stop(); err != nil {
 		t.Error(err)
 	}
+	fake.Lock()
+	defer fake.Unlock()
 	if fake.MoveCount > stopAtAction {
 		t.Error("manager did not stop playing")
 	}

--- a/device/device_test.go
+++ b/device/device_test.go
@@ -1,4 +1,4 @@
-package manager
+package device
 
 import (
 	"context"

--- a/device/doc.go
+++ b/device/doc.go
@@ -1,0 +1,6 @@
+/*
+Package device implements device managers.
+
+Device managers handles the communication with devices (like the Launch.)
+*/
+package device

--- a/launchcontrol.go
+++ b/launchcontrol.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/funjack/golaunch"
 	"github.com/funjack/launchcontrol/control"
-	"github.com/funjack/launchcontrol/manager"
+	"github.com/funjack/launchcontrol/device"
 )
 
 // Update license.go
@@ -56,7 +56,7 @@ func main() {
 		defer l.Disconnect()
 	}
 
-	lm := manager.NewLaunchManager(l)
+	lm := device.NewLaunchManager(l)
 	c := control.NewController(lm)
 
 	http.Handle("/v1/play", logger(http.HandlerFunc(c.PlayHandler)))

--- a/launchcontrol.go
+++ b/launchcontrol.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/funjack/golaunch"
-	"github.com/funjack/launchcontrol/action"
+	"github.com/funjack/launchcontrol/control"
 	"github.com/funjack/launchcontrol/manager"
 )
 
@@ -57,7 +57,7 @@ func main() {
 	}
 
 	lm := manager.NewLaunchManager(l)
-	c := action.NewController(lm)
+	c := control.NewController(lm)
 
 	http.Handle("/v1/play", logger(http.HandlerFunc(c.PlayHandler)))
 	http.Handle("/v1/stop", logger(http.HandlerFunc(c.StopHandler)))

--- a/launchcontrol.go
+++ b/launchcontrol.go
@@ -65,6 +65,7 @@ func main() {
 	http.Handle("/v1/resume", logger(http.HandlerFunc(c.ResumeHandler)))
 	http.Handle("/v1/skip", logger(http.HandlerFunc(c.SkipHandler)))
 	http.Handle("/v1/dump", logger(http.HandlerFunc(c.DumpHandler)))
+	http.Handle("/v1/socket", logger(http.HandlerFunc(c.WebsocketHandler)))
 
 	sig := make(chan os.Signal, 1)
 	signal.Notify(sig, os.Interrupt)

--- a/launchcontrol.go
+++ b/launchcontrol.go
@@ -64,6 +64,7 @@ func main() {
 	http.Handle("/v1/pause", logger(http.HandlerFunc(c.PauseHandler)))
 	http.Handle("/v1/resume", logger(http.HandlerFunc(c.ResumeHandler)))
 	http.Handle("/v1/skip", logger(http.HandlerFunc(c.SkipHandler)))
+	http.Handle("/v1/dump", logger(http.HandlerFunc(c.DumpHandler)))
 
 	sig := make(chan os.Signal, 1)
 	signal.Notify(sig, os.Interrupt)

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -104,7 +104,7 @@ func (m *LaunchManager) Play() error {
 		go func() {
 			for a := range m.player.Play() {
 				m.launch.Move(a.Position, a.Speed)
-				for t, _ := range m.tracers {
+				for t := range m.tracers {
 					select {
 					case t <- a:
 					default:

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -163,3 +163,14 @@ func (m *LaunchManager) Skip(p time.Duration) error {
 	}
 	return ErrNotPlaying
 }
+
+// Dump will return the full loaded script.
+func (m *LaunchManager) Dump() (protocol.TimedActions, error) {
+	m.Lock()
+	defer m.Unlock()
+
+	if pp, ok := m.player.(protocol.Dumpable); ok {
+		return pp.Dump()
+	}
+	return nil, ErrNotSupported
+}

--- a/protocol/player.go
+++ b/protocol/player.go
@@ -147,6 +147,13 @@ func (ta *TimedActionsPlayer) Skip(p time.Duration) error {
 	})
 }
 
+// Dump will return the loaded script as TimedActions.
+func (ta *TimedActionsPlayer) Dump() (TimedActions, error) {
+	var s = make(TimedActions, len(ta.Script))
+	copy(s, ta.Script)
+	return s, nil
+}
+
 // playbackLoop will play the loaded script to out and can be controlled using
 // ctrl.
 func (ta *TimedActionsPlayer) playbackLoop(out chan<- Action, ctrl <-chan control) {

--- a/protocol/player_test.go
+++ b/protocol/player_test.go
@@ -235,3 +235,17 @@ func TestLimits(t *testing.T) {
 
 	}
 }
+
+func TestDump(t *testing.T) {
+	p := NewTimedActionsPlayer()
+	p.Script = script
+
+	actions, err := p.Dump()
+	if err != nil {
+		t.Error(err)
+	}
+	if len(script) != len(actions) {
+		t.Errorf("dump did not return script actions: want %d, got %d",
+			len(script), len(actions))
+	}
+}

--- a/protocol/player_test.go
+++ b/protocol/player_test.go
@@ -66,7 +66,7 @@ func TestPauseResume(t *testing.T) {
 	pauseTime := time.Millisecond * 100
 
 	go func() {
-		<-time.After(time.Millisecond * 100)
+		<-time.After(time.Millisecond * 75)
 		if err := p.Pause(); err != nil {
 			t.Error(err)
 		}

--- a/protocol/types.go
+++ b/protocol/types.go
@@ -2,14 +2,15 @@
 package protocol
 
 import (
+	"encoding/json"
 	"io"
 	"time"
 )
 
 // Action is a command that can be send to a device.
 type Action struct {
-	Position int
-	Speed    int
+	Position int `json:"pos"`
+	Speed    int `json:"spd"`
 }
 
 // TimedAction wraps Action together with a timestamp.
@@ -17,6 +18,40 @@ type TimedAction struct {
 	Action
 	Time time.Duration
 }
+
+// UnmarshalJSON implements the json.Unmarshaler interface.
+func (ta *TimedAction) UnmarshalJSON(in []byte) error {
+	var c struct {
+		At  int64
+		Pos int
+		Spd int
+	}
+	err := json.Unmarshal(in, &c)
+	if err != nil {
+		return err
+	}
+	ta.Position = c.Pos
+	ta.Speed = c.Spd
+	ta.Time = time.Duration(c.At) * time.Millisecond
+	return nil
+}
+
+// MarshalJSON implements the json.Marshaler interface.
+func (ta TimedAction) MarshalJSON() ([]byte, error) {
+	c := struct {
+		At  int64 `json:"at"`
+		Pos int   `json:"pos"`
+		Spd int   `json:"spd"`
+	}{
+		At:  ta.Time.Nanoseconds() / 1e6,
+		Pos: ta.Position,
+		Spd: ta.Speed,
+	}
+	return json.Marshal(&c)
+}
+
+// TimedActions is an ordered list of TimeAction items.
+type TimedActions []TimedAction
 
 // Loader is the interface that wraps the Load method.
 type Loader interface {
@@ -70,6 +105,12 @@ type Pausable interface {
 type Skippable interface {
 	// Skip (jump) to the specified position/timecode.
 	Skip(position time.Duration) error
+}
+
+// Dumpable is a interface thtat wraps the dump method.
+type Dumpable interface {
+	// Dump the full script as TimedActions.
+	Dump() (TimedActions, error)
 }
 
 // Mover interface provides a device that can move to a position in percent

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -5,68 +5,74 @@
 		{
 			"checksumSHA1": "NzDPgT0mbeC9QH6zV91wp+Q3tCk=",
 			"path": "github.com/currantlabs/ble",
-			"revision": "0239ecbd3f6243ce3729aaa0d4d1f2a0dc666ae9",
-			"revisionTime": "2017-03-27T01:17:07Z"
+			"revision": "e7136650fe84d0fe2a2a19abc4e059e9f67bfca0",
+			"revisionTime": "2017-05-02T02:17:38Z"
 		},
 		{
 			"checksumSHA1": "y5owrBNHvwB+vM1bJuIe2QFjWWs=",
 			"path": "github.com/currantlabs/ble/darwin",
-			"revision": "0239ecbd3f6243ce3729aaa0d4d1f2a0dc666ae9",
-			"revisionTime": "2017-03-27T01:17:07Z"
+			"revision": "e7136650fe84d0fe2a2a19abc4e059e9f67bfca0",
+			"revisionTime": "2017-05-02T02:17:38Z"
 		},
 		{
 			"checksumSHA1": "cUis8vqfft/VP+tB6NFBxfbETPY=",
 			"path": "github.com/currantlabs/ble/linux",
-			"revision": "0239ecbd3f6243ce3729aaa0d4d1f2a0dc666ae9",
-			"revisionTime": "2017-03-27T01:17:07Z"
+			"revision": "e7136650fe84d0fe2a2a19abc4e059e9f67bfca0",
+			"revisionTime": "2017-05-02T02:17:38Z"
 		},
 		{
 			"checksumSHA1": "WmNlHt+3n9dDpeVdo4fZsMzeKvY=",
 			"path": "github.com/currantlabs/ble/linux/adv",
-			"revision": "0239ecbd3f6243ce3729aaa0d4d1f2a0dc666ae9",
-			"revisionTime": "2017-03-27T01:17:07Z"
+			"revision": "e7136650fe84d0fe2a2a19abc4e059e9f67bfca0",
+			"revisionTime": "2017-05-02T02:17:38Z"
 		},
 		{
 			"checksumSHA1": "EB5ZpPBgsEZi8D6bNgeQLwaMM3Q=",
 			"path": "github.com/currantlabs/ble/linux/att",
-			"revision": "0239ecbd3f6243ce3729aaa0d4d1f2a0dc666ae9",
-			"revisionTime": "2017-03-27T01:17:07Z"
+			"revision": "e7136650fe84d0fe2a2a19abc4e059e9f67bfca0",
+			"revisionTime": "2017-05-02T02:17:38Z"
 		},
 		{
-			"checksumSHA1": "mlAG1qVye9MuMBx7bN3Mh6lEamM=",
+			"checksumSHA1": "VxS2TTietVbX0bS2a/HE23ClvQU=",
 			"path": "github.com/currantlabs/ble/linux/gatt",
-			"revision": "0239ecbd3f6243ce3729aaa0d4d1f2a0dc666ae9",
-			"revisionTime": "2017-03-27T01:17:07Z"
+			"revision": "e7136650fe84d0fe2a2a19abc4e059e9f67bfca0",
+			"revisionTime": "2017-05-02T02:17:38Z"
 		},
 		{
 			"checksumSHA1": "nleMpIhBdT5EM9E3IhtY4GJ+Qbo=",
 			"path": "github.com/currantlabs/ble/linux/hci",
-			"revision": "0239ecbd3f6243ce3729aaa0d4d1f2a0dc666ae9",
-			"revisionTime": "2017-03-27T01:17:07Z"
+			"revision": "e7136650fe84d0fe2a2a19abc4e059e9f67bfca0",
+			"revisionTime": "2017-05-02T02:17:38Z"
 		},
 		{
 			"checksumSHA1": "HQ2maCL1XIsJeTxeoUeKjma403I=",
 			"path": "github.com/currantlabs/ble/linux/hci/cmd",
-			"revision": "0239ecbd3f6243ce3729aaa0d4d1f2a0dc666ae9",
-			"revisionTime": "2017-03-27T01:17:07Z"
+			"revision": "e7136650fe84d0fe2a2a19abc4e059e9f67bfca0",
+			"revisionTime": "2017-05-02T02:17:38Z"
 		},
 		{
 			"checksumSHA1": "Ud/Od1E+EqUTnoLWnKenPwptQe4=",
 			"path": "github.com/currantlabs/ble/linux/hci/evt",
-			"revision": "0239ecbd3f6243ce3729aaa0d4d1f2a0dc666ae9",
-			"revisionTime": "2017-03-27T01:17:07Z"
+			"revision": "e7136650fe84d0fe2a2a19abc4e059e9f67bfca0",
+			"revisionTime": "2017-05-02T02:17:38Z"
 		},
 		{
 			"checksumSHA1": "0yEGsIkXwHrd8H+RbEu6g4bpYaI=",
 			"path": "github.com/currantlabs/ble/linux/hci/socket",
-			"revision": "0239ecbd3f6243ce3729aaa0d4d1f2a0dc666ae9",
-			"revisionTime": "2017-03-27T01:17:07Z"
+			"revision": "e7136650fe84d0fe2a2a19abc4e059e9f67bfca0",
+			"revisionTime": "2017-05-02T02:17:38Z"
 		},
 		{
 			"checksumSHA1": "IvCm2ufb6nFHJOWrTJPUwelKrRc=",
 			"path": "github.com/funjack/golaunch",
 			"revision": "2485064409c12ea5d352a5f5156aeae7d71b8ec7",
 			"revisionTime": "2017-04-17T00:09:00Z"
+		},
+		{
+			"checksumSHA1": "hEnH6sgR83Qfx7UNnphNNlelmj0=",
+			"path": "github.com/gorilla/websocket",
+			"revision": "a91eba7f97777409bc2c443f5534d41dd20c5720",
+			"revisionTime": "2017-03-19T17:27:27Z"
 		},
 		{
 			"checksumSHA1": "uAVg4Tj5Fxi62z7/ScDEkHr6Ue8=",
@@ -107,14 +113,14 @@
 		{
 			"checksumSHA1": "Y+HGqEkYM15ir+J93MEaHdyFy0c=",
 			"path": "golang.org/x/net/context",
-			"revision": "5602c733f70afc6dcec6766be0d5034d4c4f14de",
-			"revisionTime": "2017-04-13T17:15:43Z"
+			"revision": "feeb485667d1fdabe727840fe00adc22431bc86e",
+			"revisionTime": "2017-05-02T17:39:58Z"
 		},
 		{
-			"checksumSHA1": "ArDa4bMPKzhiS1I7iioemBwZ6tE=",
+			"checksumSHA1": "oS0UZOGWVVsVciOQ8nZJ582mFF8=",
 			"path": "golang.org/x/sys/unix",
-			"revision": "f3918c30c5c2cb527c0b071a27c35120a6c0719a",
-			"revisionTime": "2017-04-05T16:58:12Z"
+			"revision": "9ccfe848b9db8435a24c424abbc07a921adf1df5",
+			"revisionTime": "2017-04-27T03:54:25Z"
 		}
 	],
 	"rootPath": "github.com/funjack/launchcontrol"


### PR DESCRIPTION
- New handler on `/v1/dump` that will dump the entire loaded script in JSON format.
- New handler on `/v1/socket` that returns a websocket, on which all Launch movement actions are broadcast.
- Refactor `manager` and `controller` packages to `device` and `control` respectfully and added package docs.
- More tests and test fixes.
